### PR TITLE
refactor: replace unnecessary String with &str & elide unused lifetime

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -24,7 +24,7 @@ pub struct Context<'a> {
     pub diff_b_result_text: Vec<Line<'a>>,
 }
 
-impl<'a> Context<'a> {
+impl Context<'_> {
     pub fn new() -> Self {
         Context {
             state: State::Edit,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -47,11 +47,10 @@ pub fn render(frame: &mut Frame, ctx: &mut Context) {
                 FocusMode::B => Style::default().fg(Color::Blue),
             }),
     );
-    let mut status_bar_message = String::from("aisudiff alpha - ");
-    status_bar_message.push_str(match ctx.state {
-        State::Edit => "Press Ctrl-s to see diff, Esc to quit",
-        State::ShowDiff => "Press Esc to return to editor",
-    });
+    let status_bar_message = match ctx.state {
+        State::Edit => "aisudiff alpha - Press Ctrl-s to see diff, Esc to quit",
+        State::ShowDiff => "aisudiff alpha - Press Esc to return to editor",
+    };
     let status_bar = Paragraph::new(status_bar_message);
     frame.render_widget(status_bar, status_area);
     if ctx.state == State::Edit {


### PR DESCRIPTION
`String` introduces overhead of heap allocation, which makes it less efficient than `&str`.